### PR TITLE
Blog posts made editable

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -16,9 +16,9 @@ use App\Http\Requests\PostRequest;
 
 class PostController extends Controller
 {
-    public function index(Post $post)//インポートしたPostをインスタンス化して$postとして使用。
+    public function index(Post $post) // インポートしたPostをインスタンス化して$postとして使用。
     {
-        return view('posts.index')->with(['posts' => $post->getPaginateByLimit(1)]);  
+        return view('posts.index')->with(['posts' => $post->getPaginateByLimit(5)]);  
        //blade内で使う変数'posts'と設定。'posts'の中身にgetを使い、インスタンス化した$postを代入。
     }
     
@@ -47,5 +47,17 @@ class PostController extends Controller
          // プロパティを上書きしたインスタンスをsave
          return redirect('/posts/' . $post->id);
          // 今回保存したpostのIDを含んだURLにリダイレクト
+     }
+     
+     public function edit(Post $post)
+     {
+         return view('posts/edit')->with(['post' => $post]);
+     }
+     
+     public function update(PostRequest $request, Post $post)
+     {
+         $input_post = $request['post'];
+         $post->fill($input_post)->save();
+         return redirect('/posts/' . $post->id);
      }
 }

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -51,7 +51,7 @@ class PostController extends Controller
      
      public function edit(Post $post)
      {
-         return view('posts/edit')->with(['post' => $post]);
+         return view('posts.edit')->with(['post' => $post]);
      }
      
      public function update(PostRequest $request, Post $post)

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -17,7 +17,7 @@ class Post extends Model
     
     public function getPaginateByLimit(int $limit_count = 5)
     {
-        // update_atで降順に並べたあと、limitで件数制限をかける
         return $this->orderBy('updated_at', 'DESC')->paginate($limit_count);
+        // updated_atカラムの降順で並び替え　// ページネーションして取得
     }
 }

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -9,22 +9,23 @@
     </head>
     <body class="antialiased">
         <h1>Blog Name</h1>
-        <form action="/posts" method="POST"> <!--action属性でリクエストを送信するURLを定義、method属性でHTTPリクエストのメソッドを指定-->
+        <form action="/posts/{{ $post->id }}" method="POST">
             @csrf <!--CSRFトークンを発行し、そのトークン情報をリクエスト時に一緒に送信-->
+            @method('PUT')
             <div class="title">
                 <h2>Title</h2>
-                <input type="text" name=post[title] placeholder="タイトル" value="{{ old('post.title') }}"/>
+                <input type="text" name=post[title] placeholder="タイトル" value="{{ $post->title }}"/>
                 <p class="title__error" style="color:red">{{ $errors->first('post.title') }}</p>
             </div>
             <div class="body">
                 <h2>Body</h2>
-                <textarea name="post[body]" placeholder="今日も一日お疲れ様でした。">{{ old('post.body') }}</textarea>
+                <textarea name="post[body]" placeholder="今日も一日お疲れ様でした。">{{ $post->body }}</textarea>
                 <p class="body__error" style="color:red">{{ $errors->first('post.body') }}</p>
             </div>
-            <input type="submit" value="store">
+            <input type="submit" value="update">
         </form>
         <div class="back">
-            [<a href="/">back</a>]
+            [<a href="/posts/{{ $post->id }}">back</a>]
         </div>
     </body>
 </html>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -17,6 +17,9 @@
                 <p>{{ $post->body }}</p>
             </div>
         </div>
+        <div class="edit">
+            [<a href="/posts/{{ $post->id }}/edit">edit</a>]
+        </div>
         <div class="back">
             [<a href="/">back</a>]
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,3 +27,6 @@ Route::get('/posts/{post}', [PostController::class, 'show']);
 // '/posts/{対照データのID}'にGetリクエストが来たら、PostControllerのshowメソッドを実行する
 
 Route::post('/posts', [PostController::class, 'store']);
+
+Route::get('/posts/{post}/edit', [PostController::class, 'edit']);
+Route::put('/posts/{post}', [PostController::class, 'update']);


### PR DESCRIPTION
ブログ投稿編集画面edit.blade.phpを実装した。また、コントローラクラスにviewファイルを返すeditメソッドと、編集処理を実行するupdateメソッドを追加した。
・edit.blade.phpでは、@method('PUT')でBladeディレクティブを定義することで、編集処理を実行するときに行うPUTリクエストを送信できるようにした
・update関数では、引数にPostデータを保持したインスタンスを$postとして扱っているが、$postのパラメータをinputで受け取ったユーザの入力データで上書きし、保存するようにした。

