### PR TITLE
Implementation of deleting blog posts

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -60,4 +60,10 @@ class PostController extends Controller
          $post->fill($input_post)->save();
          return redirect('/posts/' . $post->id);
      }
+     
+     public function delete(Post $post)
+     {
+         $post->delete();
+         return redirect('/');
+     }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -4,10 +4,12 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Post extends Model
 {
     use HasFactory;
+    use SoftDeletes;
     
     // fillが可能なプロパティを指定する
     protected $fillable = [

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -17,11 +17,27 @@
                         <a href="/posts/{{ $post->id }}">{{ $post->title }}</a>
                     </h2>
                     <p class='body'>{{ $post->body }}</p>
+                    <form action="/posts/{{ $post->id }}" id="form_{{ $post->id }}" method="post">
+                        @csrf
+                        @method('DELETE')
+                        <button type="button" onclick="deletePost({{ $post->id }})">delete</button> <!--onclickでJavaScriptのdeletePost関数を実行-->
+                    </form>
                 </div>
             @endforeach
         </div>
         <div class='paginate'>
             {{ $posts->links() }}
         </div>
+        <script>
+            function deletePost(id) {
+                'use strict'
+                
+                if (confirm('削除すると復元できません。\n本当に削除しますか？')) {
+                    document.getElementById(`form_${id}`).submit();
+                    // getElementByIdの引数にidを設定し、設定したidの要素を取得
+                    // 引数にform_がついているのは、投稿ごとに区別するため
+                }
+            }
+        </script>
     </body>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,7 +19,7 @@ Route::get('/', function () {
 });
 
 Route::get('/', [PostController::class, 'index']);
-//'/'にGetリクエストが来たら、PostControllerのshowメソッドを実行する
+//'/'にGetリクエストが来たら、PostControllerのindexメソッドを実行する
 
 Route::get('/posts/create', [PostController::class, 'create']);
 
@@ -30,3 +30,5 @@ Route::post('/posts', [PostController::class, 'store']);
 
 Route::get('/posts/{post}/edit', [PostController::class, 'edit']);
 Route::put('/posts/{post}', [PostController::class, 'update']);
+
+Route::delete('/posts/{post}', [PostController::class, 'delete']);


### PR DESCRIPTION
ブログ投稿一覧画面のdeleteボタンをクリックすると、該当ブログを論理削除できる処理を実装した
viewファイルにdelteボタンを追加し、ダイアログ画面をJavaScriptで実装した。対照idを持つURLでDELETEリクエストを実行する。
delete関数を実行するため、PostクラスにSoftDeletesの設定をした