### PR TITLE
Relation implementation for specifying and displaying categories in posts

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Category;
+
+class CategoryController extends Controller
+{
+    public function index(Category $category)
+    {
+        return view('categories.index')->with(['posts' => $category->getByCategory()]);
+    }
+}

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 //この場合、App\Models内のPostクラスをインポートしている。
 use App\Models\Post;
 use App\Http\Requests\PostRequest;
+use App\Models\Category;
 /**
  * Post一覧を表示する
  * 
@@ -34,9 +35,9 @@ class PostController extends Controller
          //'post'はbladeファイルで使う変数。中身は$postはid=1のPostインスタンス。
      }
      
-     public function create()
+     public function create(Category $category)
      {
-         return view('posts.create');
+         return view('posts.create')->with(['categories' => $category->get()]);
      }
      
      public function store(Post $post, PostRequest $request)

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Category extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -14,6 +14,11 @@ class Category extends Model
     // 「1対多」の関係なので'posts'と複数形に
     public function posts()
     {
-        return $this->hasMany(post::class);
+        return $this->hasMany(Post::class);
+    }
+    
+    public function getByCategory(int $limit_count = 5)
+    {
+        return $this->posts()->with('category')->orderBy('updated_at', 'DESC')->paginate($limit_count);
     }
 }

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -8,4 +8,12 @@ use Illuminate\Database\Eloquent\Model;
 class Category extends Model
 {
     use HasFactory;
+    
+    // Postに対するリレーション
+    
+    // 「1対多」の関係なので'posts'と複数形に
+    public function posts()
+    {
+        return $this->hasMany(post::class);
+    }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -14,12 +14,21 @@ class Post extends Model
     // fillが可能なプロパティを指定する
     protected $fillable = [
         'title',
-        'body'
+        'body',
+        'category_id'
         ];
     
     public function getPaginateByLimit(int $limit_count = 5)
     {
         return $this->orderBy('updated_at', 'DESC')->paginate($limit_count);
         // updated_atカラムの降順で並び替え　// ページネーションして取得
+    }
+    
+    //　Categoryに対するリレーション
+    
+    // 「1対多」の関係なので単数系に
+    public function category()
+    {
+        return $this->belongsTo(Category::class);
     }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -20,8 +20,8 @@ class Post extends Model
     
     public function getPaginateByLimit(int $limit_count = 5)
     {
-        return $this->orderBy('updated_at', 'DESC')->paginate($limit_count);
-        // updated_atカラムの降順で並び替え　// ページネーションして取得
+        return $this::with('category')->orderBy('updated_at', 'DESC')->paginate($limit_count);
+        // Eagerローディング機能を使って、リレーションによって増えてしまうデータベースアクセスの回数を減らす
     }
     
     //　Categoryに対するリレーション

--- a/database/migrations/2023_11_03_141500_create_categories_table.php
+++ b/database/migrations/2023_11_03_141500_create_categories_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 50);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/database/migrations/2023_11_03_150237_add_category_id_to_posts_table.php
+++ b/database/migrations/2023_11_03_150237_add_category_id_to_posts_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->foreignId('category_id')->constrained()->onDelete('cascade');
+            // 'category_id'は'categoriesテーブル'のidを参照する外部キーです
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/resources/views/categories/index.blade.php
+++ b/resources/views/categories/index.blade.php
@@ -26,6 +26,9 @@
                 </div>
             @endforeach
         </div>
+        <div class="back">
+            [<a href="/">back</a>]
+        </div>
         <div class='paginate'>
             {{ $posts->links() }}
         </div>

--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -21,6 +21,14 @@
                 <textarea name="post[body]" placeholder="今日も一日お疲れ様でした。">{{ old('post.body') }}</textarea>
                 <p class="body__error" style="color:red">{{ $errors->first('post.body') }}</p>
             </div>
+            <div class="category">
+                <h2>Category</h2>
+                <select name="post[category_id]">
+                    @foreach($categories as $category)
+                        <option value="{{ $category->id }}">{{ $category->name}}</option>
+                    @endforeach
+                </select>
+            </div>
             <input type="submit" value="store">
         </form>
         <div class="back">

--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -25,7 +25,7 @@
                 <h2>Category</h2>
                 <select name="post[category_id]">
                     @foreach($categories as $category)
-                        <option value="{{ $category->id }}">{{ $category->name}}</option>
+                        <option value="{{ $category->id }}">{{ $category->name }}</option>
                     @endforeach
                 </select>
             </div>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -17,6 +17,7 @@
                 <p>{{ $post->body }}</p>
             </div>
         </div>
+        <a href="/categories/{{ $post->category->id }}">{{ $post->category->name }}</a>
         <div class="edit">
             [<a href="/posts/{{ $post->id }}/edit">edit</a>]
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\PostController;  //外部にあるPostControllerクラスをインポート。
+use App\Http\Controllers\CategoryController;
 
 /*
 |--------------------------------------------------------------------------
@@ -32,3 +33,4 @@ Route::get('/posts/{post}/edit', [PostController::class, 'edit']);
 Route::put('/posts/{post}', [PostController::class, 'update']);
 
 Route::delete('/posts/{post}', [PostController::class, 'delete']);
+Route::get('/categories/{category}', [CategoryController::class, 'index']);


### PR DESCRIPTION
投稿にカテゴリを指定するため、以下のことをした
・categoriesテーブルをマイグレーション機能で作成して、postテーブルとのリレーションシップを実装した
・カテゴリを指定して投稿を保存するため、viewファイルにカテゴリー選択欄を追加。category_idをPostクラスのfillableに追加して、category_idを保存する処理を実装した
・カテゴリ別投稿一覧画面を表示するため、CategoryのMVCモデルを作成した

